### PR TITLE
Update for GnomAD sampling only

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,21 @@
 
 This workflow calculates geographically stratified SFS from:
 
-1. The 1000 Genomes NYGC High Coverage Data
-2. The gnomAD v3 sequencing data
+1. The gnomAD v3 sequencing data
+
 
 ### Configuring the workflow
 
-To configure the workflow please look at the example `config.yaml` and the population definitions file in `data/`
+To configure the workflow please look at the example `config.yaml`
 
-You can then adapt the sample-sizes and appropriate population labels to your own specific interests.
+You can then adapt the sample-sizes and appropriate population proportions to your own specific schemes.
+
+### Key Inference Method
+
+For subsampling the script `workflow/scripts/subsample_afs.py` can be run as a standalone python script. Currently it is run using a snakemake pipeline for the GnomAD dataset but it is portable to run for another dataset as long as the file format is similar (and that the input files contain the same/similar headers). 
+
+The `config.yaml` file indicates the individual subsampling experiments that we want to perform (defining total sample size and proportion of samples from each population defined in GnomAD). 
+
 
 ### Setup the environment
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,20 +1,21 @@
-KG_PHASE3_NYGC:
-  EUR:
-    version: "superpops"
-    n: 400
-    pops: 
-      - "EUR"
-    chroms:
-      - "chr22"
-  EUR_SAS_EAS:
-    version: "superpops"
-    n: 400
-    pops:
-      - "EUR"
-      - "EAS"
-      - "SAS"
-    chroms:
-      - "chr22"
+#KG_PHASE3_NYGC:
+  #EUR:
+    #version: "superpops"
+    #n: 400
+    #pops: 
+      #- "EUR"
+    #chroms:
+      #- "none"
+  #EUR_SAS_EAS:
+    #version: "superpops"
+    #n: 400
+    #pops:
+      #- "EUR"
+      #- "EAS"
+      #- "SAS"
+    #chroms:
+      #- "none"
 GNOMAD_V3_GENOMES:
   chroms:
     - "chr22"
+    - "chr21"

--- a/config.yaml
+++ b/config.yaml
@@ -1,21 +1,9 @@
-#KG_PHASE3_NYGC:
-  #EUR:
-    #version: "superpops"
-    #n: 400
-    #pops: 
-      #- "EUR"
-    #chroms:
-      #- "none"
-  #EUR_SAS_EAS:
-    #version: "superpops"
-    #n: 400
-    #pops:
-      #- "EUR"
-      #- "EAS"
-      #- "SAS"
-    #chroms:
-      #- "none"
 GNOMAD_V3_GENOMES:
   chroms:
     - "chr22"
     - "chr21"
+  scenarios:
+    all_nfe:
+      props: "1.0, 0.0, 0.0, 0.0, 0.0"
+      n: 10000
+

--- a/config.yaml
+++ b/config.yaml
@@ -4,6 +4,8 @@ GNOMAD_V3_GENOMES:
     - "chr21"
   scenarios:
     all_nfe:
-      props: "1.0, 0.0, 0.0, 0.0, 0.0"
+      props: "1.0, 0.0, 0.0, 0.0, 0.0" # proportion across populations
+      n: 10000 # number of samples
+    uniform_eurasia:
+      props: "0.25, 0.25, 0.25, 0.25, 0.0"
       n: 10000
-

--- a/env.yaml
+++ b/env.yaml
@@ -10,7 +10,7 @@ dependencies:
   - matplotlib
   - pip
   - bcftools
-  - snpeff
   - pip
   - pip:
     - snakefmt
+    - click

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -13,26 +13,26 @@ chroms = [f"chr{i}" for i in range(1, 23)]
 
 ### --------- Setting up the targets for the workflow -------- ###
 TARGETS = []
-seed = 42
-for POP in config["KG_PHASE3_NYGC"]:
-    n = config["KG_PHASE3_NYGC"][POP]["n"]
-    for c in config["KG_PHASE3_NYGC"][POP]["chroms"]:
-        if c == "none":
-            pass
-        if c == "all":
-            for c_tot in chroms:
-                TARGETS.append(
-                    f"results/sfs_files/kg_nygc_phase3/{POP}.{n}.{seed}.{c_tot}.sfs.tsv.gz"
-                )
-        else:
-            TARGETS.append(
-                f"results/sfs_files/kg_nygc_phase3/{POP}.{n}.{seed}.{c}.sfs.tsv.gz"
-            )
+# seed = 42
+# for POP in config["KG_PHASE3_NYGC"]:
+# n = config["KG_PHASE3_NYGC"][POP]["n"]
+# for c in config["KG_PHASE3_NYGC"][POP]["chroms"]:
+# if c == "none":
+# pass
+# elif c == "all":
+# for c_tot in chroms:
+# TARGETS.append(
+# f"results/sfs_files/kg_nygc_phase3/{POP}.{n}.{seed}.{c_tot}.sfs.tsv.gz"
+# )
+# else:
+# TARGETS.append(
+# f"results/sfs_files/kg_nygc_phase3/{POP}.{n}.{seed}.{c}.sfs.tsv.gz"
+#             )
 
 for c in config["GNOMAD_V3_GENOMES"]["chroms"]:
     if c == "none":
         pass
-    if c == "all":
+    elif c == "all":
         for c_tot in chroms:
             TARGETS.append(
                 f"results/sfs_files/gnomAD_v3/geosfs.gnomad_r3.1.2.genomes.{c_tot}.v3_expanded.tsv.gz"
@@ -132,7 +132,7 @@ rule extract_sfs_gnomAD_v3:
         chrom="chr\d+",
     shell:
         """
-        bcftools query -i \"TYPE=\'snp\' && AC > 0\" -f \"%CHROM\t%POS\t%ID\t%REF\t%ALT\t%gnomad_AC_nfe\t%gnomad_AN_nfe\t%gnomad_AC_eas\t%gnomad_AN_eas\t%gnomad_AC_sas\t%gnomad_AN_sas\t%gnomad_AC_mid\t%gnomad_AN_mid\t%gnomad_AC_oth\t%gnomad_AN_oth\t%vep\n\" https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.{wildcards.chrom}.vcf.bgz | awk \'BEGIN{{print \"CHROM\tPOS\tID\tREF\tALT\tAC_NFE\tAN_NFE\tAC_EAS\tAN_EAS\tAC_SAS\tAN_SAS\tAC_MID\tAN_MID\tAC_OTH\tAN_OTH\"}};  {{split($16, vep, \"|\"); $16=vep[2]; $17=vep[3]; print $0}}\' | bgzip > {output.tsv}
+        bcftools query -i \"TYPE=\'snp\' && AC > 0\" -f \"%CHROM\t%POS\t%ID\t%REF\t%ALT\t%gnomad_AC_nfe\t%gnomad_AN_nfe\t%gnomad_AC_eas\t%gnomad_AN_eas\t%gnomad_AC_sas\t%gnomad_AN_sas\t%gnomad_AC_mid\t%gnomad_AN_mid\t%gnomad_AC_oth\t%gnomad_AN_oth\t%vep\n\" https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.{wildcards.chrom}.vcf.bgz | awk \'BEGIN{{OFS=\"\t\"; print \"CHROM\tPOS\tID\tREF\tALT\tAC_NFE\tAN_NFE\tAC_EAS\tAN_EAS\tAC_SAS\tAN_SAS\tAC_MID\tAN_MID\tAC_OTH\tAN_OTH\tAnnot\tEffect\"}};  {{split($16, vep, \"|\"); $16=vep[2]; $17=vep[3]; print $0}}\' | bgzip > {output.tsv}
         """
 
 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -12,19 +12,22 @@ chroms = [f"chr{i}" for i in range(1, 23)]
 
 
 ### --------- Setting up the targets for the workflow -------- ###
+seed = 42
 TARGETS = []
 for c in config["GNOMAD_V3_GENOMES"]["chroms"]:
     if c == "none":
         pass
     elif c == "all":
         for c_tot in chroms:
-            TARGETS.append(
-                f"results/sfs_files/gnomAD_v3/geosfs.gnomad_r3.1.2.genomes.{c_tot}.v3_expanded.tsv.gz"
-            )
+            for scenario in config["GNOMAD_V3_GENOMES"]["scenarios"]:
+                TARGETS.append(
+                    f"results/subsample_sfs/{scenario}/gnomAD_v3.{c_tot}.seed{seed}.sfs.tsv.gz"
+                )
     else:
-        TARGETS.append(
-            f"results/sfs_files/gnomAD_v3/geosfs.gnomad_r3.1.2.genomes.{c}.v3_expanded.tsv.gz"
-        )
+        for scenario in config["GNOMAD_V3_GENOMES"]["scenarios"]:
+            TARGETS.append(
+                f"results/subsample_sfs/{scenario}/gnomAD_v3.{c}.seed{seed}.sfs.tsv.gz"
+            )
 
 
 # Just get the unique targets for the pipeline if possible.
@@ -56,14 +59,16 @@ rule subsamp_sfs_gnomAD_v3:
         subsamp_sfs_tsv="results/subsample_sfs/{scenario}/gnomAD_v3.{chrom}.seed{seed}.sfs.tsv.gz",
     params:
         poplist=["NFE", "EAS", "SAS", "MID", "OTH"],
-        props=lambda wildcards: [
-            float(x)
-            for x in config["GNOMAD_V3_GENOMES"]["scenario"][wildcards.scenario][
-                "props"
-            ].split(",")
-        ],
+        props=lambda wildcards: np.array(
+            [
+                float(x)
+                for x in config["GNOMAD_V3_GENOMES"]["scenarios"][wildcards.scenario][
+                    "props"
+                ].split(",")
+            ]
+        ),
         n=lambda wildcards: int(
-            config["GNOMAD_V3_GENOMES"]["scenario"][wildcards.scenario]["n"]
+            config["GNOMAD_V3_GENOMES"]["scenarios"][wildcards.scenario]["n"]
         ),
     script:
         "scripts/subsample_afs.py"

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -13,22 +13,6 @@ chroms = [f"chr{i}" for i in range(1, 23)]
 
 ### --------- Setting up the targets for the workflow -------- ###
 TARGETS = []
-# seed = 42
-# for POP in config["KG_PHASE3_NYGC"]:
-# n = config["KG_PHASE3_NYGC"][POP]["n"]
-# for c in config["KG_PHASE3_NYGC"][POP]["chroms"]:
-# if c == "none":
-# pass
-# elif c == "all":
-# for c_tot in chroms:
-# TARGETS.append(
-# f"results/sfs_files/kg_nygc_phase3/{POP}.{n}.{seed}.{c_tot}.sfs.tsv.gz"
-# )
-# else:
-# TARGETS.append(
-# f"results/sfs_files/kg_nygc_phase3/{POP}.{n}.{seed}.{c}.sfs.tsv.gz"
-#             )
-
 for c in config["GNOMAD_V3_GENOMES"]["chroms"]:
     if c == "none":
         pass
@@ -52,78 +36,7 @@ rule all:
         TARGETS,
 
 
-# -------------- Part 1: subpop-specific SFS from 1000 Genomes ----------------- #
-rule global_superpops:
-    input:
-        pop_tsv="data/sample_1kg_metadata.tsv",
-    output:
-        txt="results/population_files/kg_nygc_phase3/{POP}.{n}.{seed}.txt",
-    wildcard_constraints:
-        n="\d+",
-        seed="\d+",
-    params:
-        poplist=lambda wildcards: config["KG_PHASE3_NYGC"][wildcards.POP]["pops"],
-        version=lambda wildcards: config["KG_PHASE3_NYGC"][wildcards.POP]["version"],
-    run:
-        np.random.seed(int(wildcards.seed))
-        sample_df = pd.read_csv(input.pop_tsv, "\t")
-        assert "superpopulation" in sample_df.columns
-        assert "population" in sample_df.columns
-        assert "KGP_sample_id" in sample_df.columns
-        nsamp = int(int(wildcards.n) / len(params.poplist))
-        samples = []
-        for p in params.poplist:
-            if params.version == "superpops":
-                indivs = sample_df[sample_df.superpopulation == p].KGP_sample_id.values
-            else:
-                indivs = sample_df[sample_df.population == p].KGP_sample_id.values
-            for s in np.random.choice(indivs, size=nsamp, replace=False):
-                samples.append(s)
-        with open(output.txt, "w+") as out:
-            for s in samples:
-                out.write(s + "\n")
-
-
-rule subset_1kg_vcf:
-    """Subset and drop the sites of the VCF from the 1KG to reduce space and save annotations."""
-    input:
-        vcf="/scratch4/rmccoy22/sharedData/populationDatasets/1KGP_NYGC/GRCh38_phased_vcfs/1kGP_high_coverage_Illumina.{chrom}.filtered.SNV_INDEL_SV_phased_panel.vcf.gz",
-        tbi="/scratch4/rmccoy22/sharedData/populationDatasets/1KGP_NYGC/GRCh38_phased_vcfs/1kGP_high_coverage_Illumina.{chrom}.filtered.SNV_INDEL_SV_phased_panel.vcf.gz.tbi",
-        popfile="results/population_files/kg_nygc_phase3/{POP}.{n}.{seed}.txt",
-    output:
-        vcfgz=temp(
-            "results/sfs_files/kg_nygc_phase3/{POP}.{n}.{seed}.{chrom}.sfs.vcf.gz"
-        ),
-        vcfgz_tbi=temp(
-            "results/sfs_files/kg_nygc_phase3/{POP}.{n}.{seed}.{chrom}.sfs.vcf.gz.tbi"
-        ),
-    threads: 8
-    shell:
-        "bcftools view -S {input.popfile} -c 1 -v snps -G {input.vcf} --threads {threads} | bgzip -@{threads} > {output.vcfgz}; tabix -f {output.vcfgz}"
-
-
-rule annotate_1kg_vcf:
-    input:
-        vcfgz="results/sfs_files/kg_nygc_phase3/{POP}.{n}.{seed}.{chrom}.sfs.vcf.gz",
-        vcfgz_tbi="results/sfs_files/kg_nygc_phase3/{POP}.{n}.{seed}.{chrom}.sfs.vcf.gz.tbi",
-    output:
-        anno_vcfgz="results/sfs_files/kg_nygc_phase3/{POP}.{n}.{seed}.{chrom}.sfs.anno.vcf.gz",
-        anno_vcfgz_tbi="results/sfs_files/kg_nygc_phase3/{POP}.{n}.{seed}.{chrom}.sfs.anno.vcf.gz.tbi",
-    shell:
-        "snpEff hg38 {input.vcfgz} | bgzip -@{threads} > {output.anno_vcfgz}; tabix {output.anno_vcfgz}"
-
-
-rule extract_1kg_sfs:
-    """Extract the SFS."""
-    input:
-        anno_vcfgz="results/sfs_files/kg_nygc_phase3/{POP}.{n}.{seed}.{chrom}.sfs.anno.vcf.gz",
-    output:
-        "results/sfs_files/kg_nygc_phase3/{POP}.{n}.{seed}.{chrom}.sfs.tsv.gz",
-    shell:
-        'bcftools query -f "%CHROM\t%POS\t%ID\t%AN\t%AC\t%ANN\n" {input.anno_vcfgz} | awk \'{{split($6, info, "|"); OFS="\t"; print $1, $2, $3, $4, $5, info[2], info[3]}}\' | gzip > {output}'
-
-
-# ----------- 2. Annotated SFS from GnomAD v3 Genomes across multiple populations ------------------ #
+# ----------- 3. Annotated SFS from GnomAD v3 Genomes across multiple populations ------------------ #
 rule extract_sfs_gnomAD_v3:
     """Extract the pop-specific AF from GnomAD v3 Genome Data with annotations."""
     output:
@@ -134,6 +47,26 @@ rule extract_sfs_gnomAD_v3:
         """
         bcftools query -i \"TYPE=\'snp\' && AC > 0\" -f \"%CHROM\t%POS\t%ID\t%REF\t%ALT\t%gnomad_AC_nfe\t%gnomad_AN_nfe\t%gnomad_AC_eas\t%gnomad_AN_eas\t%gnomad_AC_sas\t%gnomad_AN_sas\t%gnomad_AC_mid\t%gnomad_AN_mid\t%gnomad_AC_oth\t%gnomad_AN_oth\t%vep\n\" https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.{wildcards.chrom}.vcf.bgz | awk \'BEGIN{{OFS=\"\t\"; print \"CHROM\tPOS\tID\tREF\tALT\tAC_NFE\tAN_NFE\tAC_EAS\tAN_EAS\tAC_SAS\tAN_SAS\tAC_MID\tAN_MID\tAC_OTH\tAN_OTH\tAnnot\tEffect\"}};  {{split($16, vep, \"|\"); $16=vep[2]; $17=vep[3]; print $0}}\' | bgzip > {output.tsv}
         """
+
+
+rule subsamp_sfs_gnomAD_v3:
+    input:
+        gnomAD_jsfs="results/sfs_files/gnomAD_v3/geosfs.gnomad_r3.1.2.genomes.{chrom}.v3_expanded.tsv.gz",
+    output:
+        subsamp_sfs_tsv="results/subsample_sfs/{scenario}/gnomAD_v3.{chrom}.seed{seed}.sfs.tsv.gz",
+    params:
+        poplist=["NFE", "EAS", "SAS", "MID", "OTH"],
+        props=lambda wildcards: [
+            float(x)
+            for x in config["GNOMAD_V3_GENOMES"]["scenario"][wildcards.scenario][
+                "props"
+            ].split(",")
+        ],
+        n=lambda wildcards: int(
+            config["GNOMAD_V3_GENOMES"]["scenario"][wildcards.scenario]["n"]
+        ),
+    script:
+        "scripts/subsample_afs.py"
 
 
 # ----------- 3. Using panUKBB variant listings and frequencies -------------- #

--- a/workflow/scripts/subsample_afs.py
+++ b/workflow/scripts/subsample_afs.py
@@ -101,28 +101,28 @@ def main(sfs_tsv, poplist, proportions, n=5000, seed=42, out="test.subsamp.sfs.t
 
 
 if __name__ == "__main__":
-    # try:
-    sfs_df = pd.read_csv(snakemake.input['gnomAD_jsfs'], sep="\t")
-    print("Finished Reading input SFS!")
-    # Any variants not called in a single population will be dropped ... 
-    sfs_df[sfs_df == '.'] = np.nan
-    poplist = snakemake.params['poplist']
-    an_pops = [f'AN_{p}' for p in poplist]
-    ac_pops = [f'AC_{p}' for p in poplist]
-    pop_props = snakemake.params["props"]
-    sfs_df.dropna(subset=an_pops, inplace=True)
-    # Obtain the joint allele counts for subsampling ... 
-    joint_acs = sfs_df[ac_pops].astype(int).values
-    joint_ans = sfs_df[an_pops].astype(int).values
-    max_pop_n = joint_ans.max(axis=0)
-    print("Finished subsetting SFS!")
-    print(max_pop_n)
-    subsamp_acs, subsamp_afs, _, _, ns1 = resamp_alleles_multipop(acs=joint_acs, ans=joint_ans, props=pop_props, n=int(snakemake.params['n']), seed=int(snakemake.wildcards['seed']))
-    
-    subsamp_sfs_df = sfs_df[['Annot', 'Effect']].iloc[subsamp_acs > 0,:]
-    subsamp_sfs_df['AC'] = subsamp_acs[subsamp_acs > 0]
-    subsamp_sfs_df['AF'] = subsamp_afs[subsamp_acs > 0]
-    subsamp_sfs_df['N'] = int(snakemake.params['n']) 
-    subsamp_sfs_df.to_csv(snakemake.output['subsamp_sfs_tsv'], sep="\t", index=None)
-    # except:
-    #     main()
+    try:
+        sfs_df = pd.read_csv(snakemake.input['gnomAD_jsfs'], sep="\t")
+        print("Finished Reading input SFS!")
+        # Any variants not called in a single population will be dropped ... 
+        sfs_df[sfs_df == '.'] = np.nan
+        poplist = snakemake.params['poplist']
+        an_pops = [f'AN_{p}' for p in poplist]
+        ac_pops = [f'AC_{p}' for p in poplist]
+        pop_props = snakemake.params["props"]
+        sfs_df.dropna(subset=an_pops, inplace=True)
+        # Obtain the joint allele counts for subsampling ... 
+        joint_acs = sfs_df[ac_pops].astype(int).values
+        joint_ans = sfs_df[an_pops].astype(int).values
+        max_pop_n = joint_ans.max(axis=0)
+        print("Finished subsetting SFS!")
+        print(max_pop_n)
+        subsamp_acs, subsamp_afs, _, _, ns1 = resamp_alleles_multipop(acs=joint_acs, ans=joint_ans, props=pop_props, n=int(snakemake.params['n']), seed=int(snakemake.wildcards['seed']))
+        
+        subsamp_sfs_df = sfs_df[['Annot', 'Effect']].iloc[subsamp_acs > 0,:]
+        subsamp_sfs_df['AC'] = subsamp_acs[subsamp_acs > 0]
+        subsamp_sfs_df['AF'] = subsamp_afs[subsamp_acs > 0]
+        subsamp_sfs_df['N'] = int(snakemake.params['n']) 
+        subsamp_sfs_df.to_csv(snakemake.output['subsamp_sfs_tsv'], sep="\t", index=None)
+    except:
+        main()

--- a/workflow/scripts/subsample_afs.py
+++ b/workflow/scripts/subsample_afs.py
@@ -5,11 +5,55 @@
 import numpy as np 
 import pandas as pd
 
-def pop_spread(n=100, n_pop):
-    """Determine the number of individuals to sample. """
-    pass
+def resample_alleles(ac, an, min_n = 100, n=5000, seed=42):
+    """Resample alleles for a given sample-size.
+    
+    We exclude variants where there are fewer than min_n called genotypes...
+    """
+    assert ac.size == an.size
+    assert min_n > 1
+    assert seed > 0   
+    np.random.seed(seed)
+    af = np.nan_to_num(ac/an)
+    ac_resamp = np.random.binomial(n=n, p=af)
+    af_resamp = ac_resamp / n
+    ac_resamp[an < min_n] = 0
+    af_resamp[an < min_n] = 0
+    return ac_resamp, af_resamp
 
+
+def resamp_alleles_multipop(acs, ans, props=np.array([1.0, 0.0, 0.0, 0.0, 0.0]), n=5000, seed=42):
+    """Resample multipopulation alleles ..."""
+    assert acs.shape[0] == ans.shape[0]
+    assert acs.shape[1] == ans.shape[1]
+    assert props.size == acs.shape[1]
+    assert np.all(props >= 0.0)
+    if ~np.isclose(np.sum(props), 1.0):
+        # Rescale if necessary here ... 
+        props = props / np.sum(props)
+
+    joint_acs = np.zeros(shape=acs.shape, dtype=np.uint16)
+    joint_afs = np.zeros(shape=acs.shape, dtype=np.float16)
+    new_ns = np.zeros(props.size, dtype=np.uint32)
+    for i in range(props.size):
+        # Iterate through the populations now 
+        cur_n = int(n*props[i])
+        new_ns[i] = cur_n
+        if cur_n < 1:
+            pass
+        else:
+            assert cur_n > 0
+            ac_pop, af_pop = resample_alleles(acs[:,i], ans[:,i], n=cur_n, seed=seed)
+            joint_acs[:,i] = ac_pop
+            joint_afs[:,i] = af_pop
+    meta_acs = np.sum(joint_acs, axis=1)
+    meta_afs = meta_acs / n
+    return meta_acs, meta_afs, joint_acs, joint_afs, new_ns
 
 
 if __name__ == "__main__":
-    pass
+    chr22_sfs_df = pd.read_csv(snakemake.input['gnomAD_jsfs'], sep="\t")
+    # Any variants not called in a single population will be dropped ... 
+    chr22_sfs_df[chr22_sfs_df == '.'] = np.nan
+    chr22_sfs_df.dropna(subset=['AN_NFE', 'AN_EAS', 'AN_SAS', 'AN_MID', 'AN_OTH'], inplace=True)
+    chr22_sfs_df

--- a/workflow/scripts/subsample_afs.py
+++ b/workflow/scripts/subsample_afs.py
@@ -94,8 +94,8 @@ def main(sfs_tsv, poplist, proportions, n=5000, seed=42, out="test.subsamp.sfs.t
     subsamp_acs, subsamp_afs, _, _, ns1 = resamp_alleles_multipop(acs=joint_acs, ans=joint_ans, props=props, n=n)
     
     subsamp_sfs_df = sfs_df[['Annot', 'Effect']].iloc[subsamp_acs > 0,:]
-    subsamp_sfs_df['AC'] = subsamp_acs
-    subsamp_sfs_df['AF'] = subsamp_afs
+    subsamp_sfs_df['AC'] = subsamp_acs[subsamp_acs > 0]
+    subsamp_sfs_df['AF'] = subsamp_afs[subsamp_acs > 0]
     subsamp_sfs_df['N'] = n 
     subsamp_sfs_df.to_csv(out, sep="\t", index=None)
 
@@ -103,6 +103,7 @@ def main(sfs_tsv, poplist, proportions, n=5000, seed=42, out="test.subsamp.sfs.t
 if __name__ == "__main__":
     # try:
     sfs_df = pd.read_csv(snakemake.input['gnomAD_jsfs'], sep="\t")
+    print("Finished Reading input SFS!")
     # Any variants not called in a single population will be dropped ... 
     sfs_df[sfs_df == '.'] = np.nan
     poplist = snakemake.params['poplist']
@@ -114,13 +115,14 @@ if __name__ == "__main__":
     joint_acs = sfs_df[ac_pops].astype(int).values
     joint_ans = sfs_df[an_pops].astype(int).values
     max_pop_n = joint_ans.max(axis=0)
+    print("Finished subsetting SFS!")
     print(max_pop_n)
-    subsamp_acs1, subsamp_acs1, _, _, ns1 = resamp_alleles_multipop(acs=joint_acs, ans=joint_ans, props=pop_props, n=int(snakemake.params['n']), seed=int(snakemake.wildcards['n']))
+    subsamp_acs, subsamp_afs, _, _, ns1 = resamp_alleles_multipop(acs=joint_acs, ans=joint_ans, props=pop_props, n=int(snakemake.params['n']), seed=int(snakemake.wildcards['seed']))
     
-    subsamp_sfs_df = sfs_df[['Annot', 'Effect']].iloc[joint_acs > 0,:]
-    subsamp_sfs_df['AC'] = subsamp_acs1
-    subsamp_sfs_df['AF'] = subsamp_acs1
-    subsamp_sfs_df['N'] = int(snakemake.wildcards['n'])
+    subsamp_sfs_df = sfs_df[['Annot', 'Effect']].iloc[subsamp_acs > 0,:]
+    subsamp_sfs_df['AC'] = subsamp_acs[subsamp_acs > 0]
+    subsamp_sfs_df['AF'] = subsamp_afs[subsamp_acs > 0]
+    subsamp_sfs_df['N'] = int(snakemake.params['n']) 
     subsamp_sfs_df.to_csv(snakemake.output['subsamp_sfs_tsv'], sep="\t", index=None)
     # except:
     #     main()


### PR DESCRIPTION
Small PR that limits the focus of the pipeline to just look at geographic SFS in the gnomAD dataset and perform subsampling experiments at various proportions of different ancestries. Notably the script `workflow/scripts/subsample_afs.py` can also be run as a standalone script to support experiments that are outside of this pipeline directly. 